### PR TITLE
refactor FE/BE 연락처 관련 코드 제거 및 생년월일 표시 개선

### DIFF
--- a/be/src/main/java/io/jhchoe/familytree/core/family/adapter/in/response/FamilyMemberWithRelationshipResponse.java
+++ b/be/src/main/java/io/jhchoe/familytree/core/family/adapter/in/response/FamilyMemberWithRelationshipResponse.java
@@ -10,10 +10,10 @@ import java.util.Optional;
 /**
  * Family 홈 API용 구성원과 관계 정보를 담는 응답 DTO입니다.
  * 구성원의 기본 정보와 현재 사용자와의 관계 정보를 포함합니다.
- * 
+ *
  * <p>포함 정보:</p>
  * <ul>
- *   <li>구성원 기본 정보 (이름, 나이, 생년월일, 연락처 등)</li>
+ *   <li>구성원 기본 정보 (이름, 나이, 생년월일 등)</li>
  *   <li>현재 사용자와의 관계 정보 (있는 경우)</li>
  *   <li>관계 표시명 (설정된 관계가 있는 경우)</li>
  * </ul>
@@ -133,17 +133,6 @@ public class FamilyMemberWithRelationshipResponse {
     }
     
     /**
-     * 구성원 연락처를 반환합니다.
-     * 
-     * @return 구성원 연락처
-     */
-    public String getMemberPhoneNumber() {
-        // FamilyMember에 phoneNumber 필드가 없으므로 일단 null 반환
-        // 향후 도메인 확장 시 추가 예정
-        return null;
-    }
-    
-    /**
      * 구성원 프로필 이미지 URL을 반환합니다.
      * 
      * @return 프로필 이미지 URL
@@ -194,18 +183,6 @@ public class FamilyMemberWithRelationshipResponse {
         } else {
             return "관계를 설정해주세요";
         }
-    }
-    
-    /**
-     * 연락처 표시 정보를 반환합니다.
-     * 연락처가 없는 경우 적절한 안내 메시지를 반환합니다.
-     * 
-     * @return 연락처 표시 정보
-     */
-    public String getPhoneNumberDisplay() {
-        // FamilyMember에 phoneNumber 필드가 없으므로 일단 "연락처 없음" 반환
-        // 향후 도메인 확장 시 수정 예정
-        return "연락처 없음";
     }
     
     /**

--- a/fe/src/api/services/familyService.ts
+++ b/fe/src/api/services/familyService.ts
@@ -73,9 +73,8 @@ export interface FamilyMemberWithRelationship {
   memberName: string;
   memberAge?: number;
   memberBirthday?: string;
-  memberPhoneNumber?: string;
   memberProfileImageUrl?: string;
-  
+
   // 관계 정보
   relationshipDisplayName?: string;
   relationshipType?: FamilyMemberRelationshipType;
@@ -83,8 +82,7 @@ export interface FamilyMemberWithRelationship {
   hasRelationship: boolean;
   relationshipSetupRequired: boolean;
   relationshipGuideMessage: string;
-  phoneNumberDisplay: string;
-  
+
   // 편의 접근자 (백엔드 응답에서 flatten된 형태)
   member: FamilyMember;
 }
@@ -96,10 +94,8 @@ export interface UIFamilyMember {
   profileImage?: string;
   age?: number;
   birthDate?: string;
-  phoneNumber?: string;
   relationship?: string;
   customRelationship?: string;
-  isKakaoSynced?: boolean;
   role: "ADMIN" | "MEMBER" | "SUSPENDED";
 }
 

--- a/fe/src/components/family/FamilyMemberCard/FamilyMemberCard.tsx
+++ b/fe/src/components/family/FamilyMemberCard/FamilyMemberCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Phone, Heart } from 'lucide-react';
+import { Heart, Cake } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
@@ -25,25 +25,6 @@ export function FamilyMemberCard({
       return memberWithRelationship.customRelationshipName;
     }
     return memberWithRelationship.relationshipDisplayName || "관계 정보 없음";
-  };
-
-  const getContactDisplay = () => {
-    if (!memberWithRelationship.memberPhoneNumber) {
-      return "연락처 없음";
-    }
-    // TODO: 카카오톡 동기화 상태는 백엔드에서 제공될 예정
-    return formatPhoneNumber(memberWithRelationship.memberPhoneNumber);
-  };
-
-  const formatPhoneNumber = (phone: string): string => {
-    const cleaned = phone.replace(/\D/g, '');
-    if (cleaned.length === 11) {
-      return cleaned.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
-    }
-    if (cleaned.length === 10) {
-      return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
-    }
-    return phone;
   };
 
   const formatBirthDate = (dateString?: string): string => {
@@ -112,26 +93,17 @@ export function FamilyMemberCard({
               </span>
             </div>
 
-            {memberWithRelationship.memberAge && (
-              <div className="text-body2 text-gray-600 mb-2 flex items-center gap-2">
-                <span className="font-medium">{memberWithRelationship.memberAge}세</span>
-                <span className="text-gray-400">•</span>
-                <span>{formatBirthDate(memberWithRelationship.memberBirthday)}</span>
-              </div>
-            )}
-
-            <div className="flex items-center gap-2 text-body2 mb-4">
-              <Phone className="w-4 h-4 text-gray-400" />
-              <span
-                className={cn(
-                  "font-medium",
-                  !memberWithRelationship.memberPhoneNumber
-                    ? "text-gray-400"
-                    : "text-gray-600",
-                )}
-              >
-                {getContactDisplay()}
-              </span>
+            <div className="flex items-center gap-2 text-body2 text-gray-600 mb-4">
+              <Cake className="w-4 h-4 text-gray-400" />
+              {memberWithRelationship.memberAge ? (
+                <>
+                  <span className="font-medium">{memberWithRelationship.memberAge}세</span>
+                  <span className="text-gray-400">•</span>
+                  <span>{formatBirthDate(memberWithRelationship.memberBirthday)}</span>
+                </>
+              ) : (
+                <span className="text-gray-400">{formatBirthDate(memberWithRelationship.memberBirthday)}</span>
+              )}
             </div>
           </div>
 

--- a/fe/src/pages/FamilyMembersPage.tsx
+++ b/fe/src/pages/FamilyMembersPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useFamilyMembers, useFamilyDetail } from '../hooks/queries/useFamilyQueries';
 import { FamilyMemberWithRelationship } from '../api/services/familyService';
-import { ArrowLeft, Users, Plus, Phone, ChevronRight, Settings } from 'lucide-react';
+import { ArrowLeft, Users, Plus, ChevronRight, Settings } from 'lucide-react';
 
 const FamilyMembersPage: React.FC = () => {
   const { familyId } = useParams<{ familyId: string }>();
@@ -97,15 +97,6 @@ const FamilyMembersPage: React.FC = () => {
                     {member.relationshipGuideMessage || '-'}
                   </p>
                 </div>
-                {member.memberPhoneNumber && (
-                  <a
-                    href={`tel:${member.memberPhoneNumber}`}
-                    className="w-6 h-6 rounded bg-green-50 flex items-center justify-center flex-shrink-0"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Phone className="w-3 h-3 text-green-600" strokeWidth={1.5} />
-                  </a>
-                )}
                 <ChevronRight className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" strokeWidth={1.5} />
               </div>
             ))}

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMyFamilies, useFamilyMembers } from '../hooks/queries/useFamilyQueries';
 import { FamilyMemberWithRelationship } from '../api/services/familyService';
-import { Search, Plus, UserPlus, LogOut, ChevronRight, Phone } from 'lucide-react';
+import { Search, Plus, UserPlus, LogOut, ChevronRight } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -23,13 +23,19 @@ const HomePage: React.FC = () => {
     }
   }, [familiesData, selectedFamilyId]);
 
+  const formatBirthDate = (dateString?: string): string => {
+    if (!dateString) return '-';
+    const date = new Date(dateString);
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${month}.${day}`;
+  };
+
   const filteredMembers = useMemo(() => {
     if (!membersData || !searchTerm) return membersData || [];
 
     return membersData.filter((member: FamilyMemberWithRelationship) =>
-      member.memberName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      member.memberPhoneNumber?.includes(searchTerm) ||
-      member.phoneNumberDisplay?.includes(searchTerm)
+      member.memberName.toLowerCase().includes(searchTerm.toLowerCase())
     );
   }, [membersData, searchTerm]);
 
@@ -98,18 +104,9 @@ const HomePage: React.FC = () => {
                     {member.memberName}
                   </p>
                   <p className="text-[10px] text-muted-foreground truncate">
-                    {member.phoneNumberDisplay || '-'}
+                    {member.memberAge ? `${member.memberAge}세` : ''} {formatBirthDate(member.memberBirthday)}
                   </p>
                 </div>
-                {member.memberPhoneNumber && (
-                  <a
-                    href={`tel:${member.memberPhoneNumber}`}
-                    className="w-5 h-5 rounded-md bg-green-50 flex items-center justify-center flex-shrink-0"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Phone className="w-2.5 h-2.5 text-green-600" strokeWidth={1.5} />
-                  </a>
-                )}
                 <ChevronRight className="w-3 h-3 text-muted-foreground flex-shrink-0" strokeWidth={1.5} />
               </div>
             ))}


### PR DESCRIPTION
- 서비스에서 사용하지 않는 연락처 관련 코드 전체 제거
- FE에서 생년월일 표시 기능 추가 (Cake 아이콘 사용)

## 변경된 컴포넌트

### 백엔드
- FamilyMemberWithRelationshipResponse.java: getMemberPhoneNumber(), getPhoneNumberDisplay() 메서드 제거

### 프론트엔드
- FamilyMemberCard.tsx: Phone 아이콘 제거, Cake 아이콘으로 생년월일 표시
- HomePage.tsx: 연락처 검색 제거, 생년월일 표시 추가
- FamilyMembersPage.tsx: tel: 링크 버튼 제거
- familyService.ts: memberPhoneNumber, phoneNumberDisplay 타입 정의 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 가족 구성원 정보에서 전화번호 데이터 제거

* **스타일**
  * 가족 구성원 카드에서 생년월일 및 나이 정보 표시 개선
  * 전화 아이콘 대신 생일 아이콘으로 변경하여 사용자 인터페이스 업데이트
  * 가족 구성원 목록 및 홈 화면에서 전화 연락처 표시 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->