### PR TITLE
feat(fe): PRD-006 Sprint 4 태그별 필터링 기능 구현

### DIFF
--- a/fe/src/components/family/TagBadge.tsx
+++ b/fe/src/components/family/TagBadge.tsx
@@ -19,7 +19,7 @@ interface TagBadgeProps {
 /**
  * 배경색의 밝기를 계산하여 텍스트 색상 결정
  */
-function getContrastTextColor(hexColor: string): string {
+export function getContrastTextColor(hexColor: string): string {
   // HEX를 RGB로 변환
   const hex = hexColor.replace('#', '');
   const r = parseInt(hex.substring(0, 2), 16);

--- a/fe/src/components/family/TagFilter.tsx
+++ b/fe/src/components/family/TagFilter.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { Check, ChevronDown, Filter } from 'lucide-react';
+import { useTags } from '@/hooks/queries/useTagQueries';
+import { cn } from '@/lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+
+interface TagFilterProps {
+  familyId: number;
+  selectedTagIds: number[];
+  onSelectionChange: (tagIds: number[]) => void;
+  filteredCount?: number;
+  className?: string;
+}
+
+export const TagFilter: React.FC<TagFilterProps> = ({
+  familyId,
+  selectedTagIds,
+  onSelectionChange,
+  filteredCount,
+  className,
+}) => {
+  const { data: tags, isLoading } = useTags(familyId);
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = (tagId: number) => {
+    if (selectedTagIds.includes(tagId)) {
+      onSelectionChange(selectedTagIds.filter((id) => id !== tagId));
+    } else {
+      onSelectionChange([...selectedTagIds, tagId]);
+    }
+  };
+
+  const handleClearSelection = () => {
+    onSelectionChange([]);
+  };
+
+  // 태그가 없거나 로딩 중이면 렌더링하지 않음
+  if (isLoading || !tags || tags.length === 0) {
+    return null;
+  }
+
+  const hasSelection = selectedTagIds.length > 0;
+
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(
+                'h-7 gap-1 text-xs px-1.5',
+                hasSelection && 'text-primary'
+              )}
+            >
+              <Filter className="w-3 h-3" />
+              {hasSelection && <span>{selectedTagIds.length}개</span>}
+              <ChevronDown className="w-3 h-3 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-56 p-2">
+            {/* 태그 목록 */}
+            <div className="flex flex-col gap-1 max-h-64 overflow-y-auto">
+              {tags.map((tag) => {
+                const isSelected = selectedTagIds.includes(tag.id);
+                return (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    onClick={() => handleToggle(tag.id)}
+                    className={cn(
+                      'flex items-center gap-2 px-2 py-1.5 rounded-md text-sm',
+                      'hover:bg-secondary transition-colors text-left w-full',
+                      isSelected && 'bg-secondary/80'
+                    )}
+                  >
+                    {/* 체크박스 */}
+                    <div
+                      className={cn(
+                        'w-4 h-4 rounded border flex items-center justify-center flex-shrink-0',
+                        isSelected
+                          ? 'bg-primary border-primary'
+                          : 'border-muted-foreground/30'
+                      )}
+                    >
+                      {isSelected && (
+                        <Check className="w-3 h-3 text-primary-foreground" />
+                      )}
+                    </div>
+                    {/* 색상 원 */}
+                    <span
+                      className="w-3 h-3 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: tag.color }}
+                    />
+                    {/* 태그 이름 */}
+                    <span className="truncate">{tag.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* 선택 취소 */}
+            {hasSelection && (
+              <>
+                <div className="border-t border-border my-2" />
+                <button
+                  type="button"
+                  onClick={handleClearSelection}
+                  className="w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-secondary rounded-md transition-colors text-left"
+                >
+                  선택 취소
+                </button>
+              </>
+            )}
+          </PopoverContent>
+        </Popover>
+
+      {/* 필터 상태 표시 */}
+      {hasSelection && filteredCount !== undefined && (
+        <span className="text-xs text-muted-foreground mr-1">
+          {filteredCount}명
+        </span>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## 변경 목적
- 멤버 목록에서 태그를 기준으로 필터링할 수 있는 기능 추가

## 변경 내용

### 주요 변경사항
- `TagFilter` 컴포넌트 신규 구현 (Popover 기반 멀티셀렉트)
- `HomePage`에 태그 필터 통합 (검색 + 태그 필터 조합 가능)
- 태그 필터링은 OR 조건 (선택한 태그 중 하나라도 포함된 멤버 표시)
- 필터 적용 시 결과 멤버 수 표시

### 구현된 컴포넌트
- `TagFilter.tsx`: 태그 필터 Popover 컴포넌트
- `TagBadge.tsx`: `getContrastTextColor` 함수 export 추가

## 관련 문서
- PRD: `development-docs/prd-006-tag-management.md`

---

@claude 이 PR을 다음 전문가 관점에서 리뷰해주세요:
- 시니어 백엔드 개발자
- 시니어 프론트엔드 개발자
- 시니어 UI/UX 디자이너
- 시니어 DevOps 엔지니어
- 비용 최적화 전문가

피드백에는 우선순위 라벨을 붙여주세요:
- `[P0-CRITICAL]`: 반드시 수정 필요
- `[P1-MAJOR]`: 수정 강력 권장
- `[P2-MINOR]`: 개선 제안
- `[P3-NITPICK]`: 사소한 제안

리뷰 마지막에 다음을 포함해주세요:
1. 전체 평가 (상/중/하)
2. 주요 개선 사항 요약
3. 칭찬할 점
4. 이 PR에서 학습할 키워드

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 가족 구성원을 태그로 필터링할 수 있는 기능이 추가되었습니다.
* 태그 필터를 사용하여 특정 태그의 구성원을 빠르게 선택하고 조회할 수 있습니다.
* 검색과 함께 태그 필터를 조합하여 더욱 정확하게 원하는 구성원을 찾을 수 있습니다.
* 선택된 태그의 개수가 표시되어 현재 필터 상태를 한눈에 파악할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->