### PR TITLE
fix: Claude Code Review가 PR 코멘트를 남기도록 수정

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          claude_args: |
+            --allowedTools "mcp__github__create_or_update_file,mcp__github__create_pull_request_review,mcp__github__add_pull_request_review_comment,Bash(gh pr comment:*),Bash(gh pr review:*)"
           prompt: |
             이 PR을 다음 전문가 관점에서 리뷰해주세요:
             - 시니어 백엔드 개발자


### PR DESCRIPTION
문제: prompt 파라미터 사용 시 agent mode가 자동 선택되어
PR 코멘트 작성이 비활성화됨 (Actions Summary에만 표시)

해결:
- use_sticky_comment: true 추가
- claude_args에 allowedTools 명시적 설정
  - PR 리뷰 및 코멘트 작성 도구 허용

참고: https://github.com/anthropics/claude-code-action/issues/621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기타(Chores)**
  * 코드 리뷰 자동화 워크플로우 구성이 개선되었습니다. 리뷰 프로세스의 안정성과 효율성이 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->