### PR TITLE
feat(fe): 멤버 기본 정보 수정 기능 구현 (#52)

### DIFF
--- a/fe/src/api/services/familyService.ts
+++ b/fe/src/api/services/familyService.ts
@@ -124,6 +124,18 @@ export interface UpdateFamilyMemberForm {
   nationality?: string;
 }
 
+// 구성원 기본 정보 수정 요청
+export interface ModifyFamilyMemberInfoRequest {
+  name: string;
+  birthday?: string;
+  birthdayType?: BirthdayType;
+}
+
+// 구성원 기본 정보 수정 응답
+export interface ModifyFamilyMemberInfoResponse {
+  id: number;
+}
+
 // 가족 관계 관련 타입들 - types/family.ts에서 import
 
 
@@ -326,6 +338,20 @@ export class FamilyService {
   ): Promise<{ id: number }> {
     return this.apiClient.patch<{ id: number }>(
       `/api/families/${familyId}/members/${memberId}/relationship`,
+      request
+    );
+  }
+
+  /**
+   * 가족 구성원의 기본 정보(이름, 생일, 생일타입)를 수정합니다.
+   */
+  public async modifyMemberInfo(
+    familyId: number | string,
+    memberId: number | string,
+    request: ModifyFamilyMemberInfoRequest
+  ): Promise<ModifyFamilyMemberInfoResponse> {
+    return this.apiClient.put<ModifyFamilyMemberInfoResponse>(
+      `/api/families/${familyId}/members/${memberId}/info`,
       request
     );
   }

--- a/fe/src/components/family/MemberEditModal.tsx
+++ b/fe/src/components/family/MemberEditModal.tsx
@@ -1,0 +1,186 @@
+/**
+ * 구성원 기본 정보 수정 모달 컴포넌트
+ * 이름, 생일, 생일타입(음력/양력)을 수정합니다.
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useModifyMemberInfo } from '@/hooks/queries/useFamilyQueries';
+import { useToast } from '@/hooks/use-toast';
+import { BirthdayType } from '@/api/services/familyService';
+import { formatThisYearSolarBirthday } from '@/utils/lunar';
+
+interface MemberEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  familyId: number | string;
+  memberId: number | string;
+  currentName: string;
+  currentBirthday?: string;
+  currentBirthdayType?: BirthdayType;
+  onSuccess?: () => void;
+}
+
+const birthdayTypeOptions = [
+  { value: 'SOLAR', label: '양력' },
+  { value: 'LUNAR', label: '음력' },
+];
+
+export const MemberEditModal: React.FC<MemberEditModalProps> = ({
+  open,
+  onOpenChange,
+  familyId,
+  memberId,
+  currentName,
+  currentBirthday,
+  currentBirthdayType,
+  onSuccess,
+}) => {
+  const [name, setName] = useState(currentName);
+  const [birthday, setBirthday] = useState('');
+  const [birthdayType, setBirthdayType] = useState<BirthdayType>(currentBirthdayType || 'SOLAR');
+
+  const { toast } = useToast();
+  const modifyInfoMutation = useModifyMemberInfo();
+
+  const isSubmitDisabled = !name.trim() || modifyInfoMutation.isPending;
+
+  // 음력일 때 양력 변환 날짜 계산
+  const solarBirthdayDisplay = birthdayType === 'LUNAR' && birthday
+    ? formatThisYearSolarBirthday(birthday)
+    : null;
+
+  const resetForm = () => {
+    setName(currentName);
+    setBirthday(currentBirthday ? currentBirthday.split('T')[0] : '');
+    setBirthdayType(currentBirthdayType || 'SOLAR');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+
+    try {
+      await modifyInfoMutation.mutateAsync({
+        familyId,
+        memberId,
+        request: {
+          name: name.trim(),
+          birthday: birthday ? `${birthday}T00:00:00` : undefined,
+          birthdayType: birthday ? birthdayType : undefined,
+        },
+      });
+
+      toast({ title: '정보가 수정되었습니다.' });
+      onOpenChange(false);
+      onSuccess?.();
+    } catch {
+      toast({ title: '정보 수정에 실패했습니다.', variant: 'destructive' });
+    }
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      resetForm();
+    }
+    onOpenChange(isOpen);
+  };
+
+  // 모달이 열릴 때 현재 값으로 초기화
+  useEffect(() => {
+    if (open) {
+      setName(currentName);
+      setBirthday(currentBirthday ? currentBirthday.split('T')[0] : '');
+      setBirthdayType(currentBirthdayType || 'SOLAR');
+    }
+  }, [open, currentName, currentBirthday, currentBirthdayType]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>구성원 정보 수정</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">
+              이름 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="이름을 입력하세요"
+              maxLength={50}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="birthday">생일</Label>
+            <Input
+              id="birthday"
+              type="date"
+              value={birthday}
+              onChange={(e) => setBirthday(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="birthdayType">생일 유형</Label>
+            <Select
+              value={birthdayType || 'SOLAR'}
+              onValueChange={(value) => setBirthdayType(value as BirthdayType)}
+            >
+              <SelectTrigger id="birthdayType">
+                <SelectValue placeholder="생일 유형 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {birthdayTypeOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {solarBirthdayDisplay && (
+              <p className="text-sm text-muted-foreground">
+                올해 양력: {solarBirthdayDisplay}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={isSubmitDisabled}>
+              {modifyInfoMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/fe/src/components/family/__tests__/MemberEditModal.test.tsx
+++ b/fe/src/components/family/__tests__/MemberEditModal.test.tsx
@@ -1,0 +1,312 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemberEditModal } from '../MemberEditModal';
+
+// Mock useModifyMemberInfo hook
+const mockMutateAsync = jest.fn();
+jest.mock('@/hooks/queries/useFamilyQueries', () => ({
+  useModifyMemberInfo: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// Mock useToast hook
+const mockToast = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+// Mock formatThisYearSolarBirthday
+jest.mock('@/utils/lunar', () => ({
+  formatThisYearSolarBirthday: jest.fn((birthday: string) => {
+    // 간단한 mock 반환값
+    return '04.15';
+  }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('MemberEditModal', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+    familyId: 1,
+    memberId: 2,
+    currentName: '홍길동',
+    onSuccess: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('렌더링', () => {
+    it('모달이 열리면 제목이 표시된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText('구성원 정보 수정')).toBeInTheDocument();
+    });
+
+    it('이름 입력 필드가 현재 이름으로 초기화된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByLabelText(/이름/)).toHaveValue('홍길동');
+    });
+
+    it('생일 입력 필드가 표시된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByLabelText('생일')).toBeInTheDocument();
+    });
+
+    it('생일 유형 선택 필드가 표시된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByLabelText('생일 유형')).toBeInTheDocument();
+    });
+
+    it('저장 및 취소 버튼이 표시된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByRole('button', { name: '저장' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+    });
+
+    it('현재 생일이 있으면 초기값으로 설정된다', () => {
+      render(
+        <MemberEditModal
+          {...defaultProps}
+          currentBirthday="1990-03-15T00:00:00"
+          currentBirthdayType="SOLAR"
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      const birthdayInput = screen.getByLabelText('생일');
+      expect(birthdayInput).toHaveValue('1990-03-15');
+    });
+
+    it('음력 생일일 때 생일 유형이 음력으로 표시된다', () => {
+      render(
+        <MemberEditModal
+          {...defaultProps}
+          currentBirthday="1990-03-15T00:00:00"
+          currentBirthdayType="LUNAR"
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      // Select combobox에서 음력이 선택되어 있는지 확인
+      const selectTrigger = screen.getByRole('combobox');
+      expect(selectTrigger).toHaveTextContent('음력');
+    });
+  });
+
+  describe('유효성 검사', () => {
+    it('이름이 비어있으면 저장 버튼이 비활성화된다', async () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      const nameInput = screen.getByLabelText(/이름/);
+      await userEvent.clear(nameInput);
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('이름이 있으면 저장 버튼이 활성화된다', () => {
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('버튼 인터랙션', () => {
+    it('취소 버튼 클릭 시 onOpenChange(false)가 호출된다', async () => {
+      const onOpenChange = jest.fn();
+      render(
+        <MemberEditModal {...defaultProps} onOpenChange={onOpenChange} />,
+        { wrapper: createWrapper() }
+      );
+
+      const cancelButton = screen.getByRole('button', { name: '취소' });
+      await userEvent.click(cancelButton);
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('이름 변경 후 저장하면 mutateAsync가 호출된다', async () => {
+      mockMutateAsync.mockResolvedValueOnce({ id: 2 });
+
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      const nameInput = screen.getByLabelText(/이름/);
+      await userEvent.clear(nameInput);
+      await userEvent.type(nameInput, '김철수');
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          familyId: 1,
+          memberId: 2,
+          request: {
+            name: '김철수',
+            birthday: undefined,
+            birthdayType: undefined,
+          },
+        });
+      });
+    });
+
+    it('생일과 함께 저장하면 생일 정보도 전송된다', async () => {
+      mockMutateAsync.mockResolvedValueOnce({ id: 2 });
+
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      const birthdayInput = screen.getByLabelText('생일');
+      await userEvent.type(birthdayInput, '1990-05-20');
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          familyId: 1,
+          memberId: 2,
+          request: {
+            name: '홍길동',
+            birthday: '1990-05-20T00:00:00',
+            birthdayType: 'SOLAR',
+          },
+        });
+      });
+    });
+  });
+
+  describe('모달 상태', () => {
+    it('모달이 닫혀있으면 내용이 표시되지 않는다', () => {
+      render(<MemberEditModal {...defaultProps} open={false} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.queryByText('구성원 정보 수정')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('제출 및 토스트', () => {
+    it('정보 수정 성공 시 성공 토스트가 표시된다', async () => {
+      mockMutateAsync.mockResolvedValueOnce({ id: 2 });
+      const onSuccess = jest.fn();
+
+      render(
+        <MemberEditModal {...defaultProps} onSuccess={onSuccess} />,
+        { wrapper: createWrapper() }
+      );
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalled();
+        expect(mockToast).toHaveBeenCalledWith({ title: '정보가 수정되었습니다.' });
+        expect(onSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('정보 수정 실패 시 에러 토스트가 표시된다', async () => {
+      mockMutateAsync.mockRejectedValueOnce(new Error('API Error'));
+
+      render(<MemberEditModal {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalled();
+        expect(mockToast).toHaveBeenCalledWith({
+          title: '정보 수정에 실패했습니다.',
+          variant: 'destructive',
+        });
+      });
+    });
+
+    it('저장 성공 시 모달이 닫힌다', async () => {
+      mockMutateAsync.mockResolvedValueOnce({ id: 2 });
+      const onOpenChange = jest.fn();
+
+      render(
+        <MemberEditModal {...defaultProps} onOpenChange={onOpenChange} />,
+        { wrapper: createWrapper() }
+      );
+
+      const submitButton = screen.getByRole('button', { name: '저장' });
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe('폼 초기화', () => {
+    it('모달이 열릴 때 현재 값으로 초기화된다', () => {
+      const { rerender } = render(
+        <MemberEditModal {...defaultProps} open={false} />,
+        { wrapper: createWrapper() }
+      );
+
+      rerender(
+        <QueryClientProvider
+          client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+        >
+          <MemberEditModal
+            {...defaultProps}
+            open={true}
+            currentName="김철수"
+            currentBirthday="1985-01-01T00:00:00"
+            currentBirthdayType="LUNAR"
+          />
+        </QueryClientProvider>
+      );
+
+      expect(screen.getByLabelText(/이름/)).toHaveValue('김철수');
+      expect(screen.getByLabelText('생일')).toHaveValue('1985-01-01');
+    });
+  });
+});

--- a/fe/src/hooks/queries/useFamilyQueries.ts
+++ b/fe/src/hooks/queries/useFamilyQueries.ts
@@ -10,7 +10,8 @@ import {
   ModifyFamilyRequest,
   CreateFamilyMemberForm,
   UpdateFamilyMemberForm,
-  FamilyJoinRequestStatus
+  FamilyJoinRequestStatus,
+  ModifyFamilyMemberInfoRequest
 } from '../../api/services/familyService';
 import {
   FamilyMemberRelationshipType,
@@ -319,6 +320,35 @@ export const useModifyMemberRelationship = () => {
       relationshipType,
       customRelationship,
     }),
+    onSuccess: (_, { familyId, memberId }) => {
+      // 해당 구성원 정보 무효화
+      queryClient.invalidateQueries({
+        queryKey: familyQueryKeys.member(familyId, memberId),
+      });
+      // 가족 구성원 목록 무효화
+      queryClient.invalidateQueries({
+        queryKey: familyQueryKeys.members(familyId),
+      });
+    },
+  });
+};
+
+/**
+ * 가족 구성원의 기본 정보(이름, 생일, 생일타입)를 수정합니다.
+ */
+export const useModifyMemberInfo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      familyId,
+      memberId,
+      request,
+    }: {
+      familyId: number | string;
+      memberId: number | string;
+      request: ModifyFamilyMemberInfoRequest;
+    }) => familyService.modifyMemberInfo(familyId.toString(), memberId.toString(), request),
     onSuccess: (_, { familyId, memberId }) => {
       // 해당 구성원 정보 무효화
       queryClient.invalidateQueries({

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMyFamilies, useFamilyMembers } from '../hooks/queries/useFamilyQueries';
 import { FamilyMemberWithRelationship } from '../api/services/familyService';
-import { Search, Plus, UserPlus, LogOut, ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
+import { Search, Plus, UserPlus, LogOut, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -210,13 +210,12 @@ const HomePage: React.FC = () => {
                     </div>
                     <div className="flex items-center gap-1 flex-shrink-0">
                       {member.memberBirthday && (
-                        <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                        <span className="text-xs text-muted-foreground flex items-center gap-1">
                           {formatBirthday(member.memberBirthday, member.memberBirthdayType ?? null)}
                           {member.memberBirthdayType === 'LUNAR' && (
-                            <>
-                              <ArrowRight className="w-3 h-3" strokeWidth={1.5} />
-                              <span>{formatThisYearSolarBirthday(member.memberBirthday)}</span>
-                            </>
+                            <span className="text-muted-foreground/70">
+                              (올해 양력: {formatThisYearSolarBirthday(member.memberBirthday)})
+                            </span>
                           )}
                         </span>
                       )}


### PR DESCRIPTION
## Summary
- MemberDetailSheet에서 멤버 기본 정보(이름, 생일, 음력/양력) 수정 기능 추가
- 음력 생일 시 '올해 양력: MM.DD' 형식으로 UI 통일

## Changes
- `MemberEditModal` 컴포넌트 신규 추가
- `useModifyMemberInfo` React Query 훅 추가 (캐시 무효화 패턴)
- `MemberDetailSheet`에 편집 버튼(✏️) 및 모달 연동
- HomePage, MemberDetailSheet, MemberEditModal 음력→양력 표시 형식 통일

## Test plan
- [x] MemberEditModal 테스트 17개 추가
- [x] 전체 테스트 91개 통과
- [ ] 멤버 상세 시트에서 편집 버튼 클릭 → 모달 열림 확인
- [ ] 이름/생일/음력 수정 후 저장 → 목록 반영 확인
- [ ] 음력 생일 시 '올해 양력: MM.DD' 표시 확인

## Related
- Backend PR: #58
- Issue: #52

🤖 Generated with [Claude Code](https://claude.ai/code)