### PR TITLE
feat: 초대된 멤버의 생일 수정 권한 제한 (#52)

### DIFF
--- a/be/src/main/java/io/jhchoe/familytree/core/family/application/service/ModifyFamilyMemberInfoService.java
+++ b/be/src/main/java/io/jhchoe/familytree/core/family/application/service/ModifyFamilyMemberInfoService.java
@@ -55,14 +55,19 @@ public class ModifyFamilyMemberInfoService implements ModifyFamilyMemberInfoUseC
             throw new FTException(FamilyExceptionCode.SELF_MODIFICATION_NOT_ALLOWED);
         }
 
-        // 6. 정보 변경
+        // 6. 초대된 멤버(userId 있음)의 생일/생일타입은 본인만 수정 가능
+        if (targetMember.getUserId() != null && (command.birthday() != null || command.birthdayType() != null)) {
+            throw new FTException(FamilyExceptionCode.INVITED_MEMBER_BIRTHDAY_MODIFICATION_NOT_ALLOWED);
+        }
+
+        // 7. 정보 변경
         FamilyMember updatedMember = targetMember.modifyInfo(
             command.name(),
             command.birthday(),
             command.birthdayType()
         );
 
-        // 7. 저장
+        // 8. 저장
         return modifyFamilyMemberPort.modify(updatedMember);
     }
 }

--- a/be/src/main/java/io/jhchoe/familytree/core/family/exception/FamilyExceptionCode.java
+++ b/be/src/main/java/io/jhchoe/familytree/core/family/exception/FamilyExceptionCode.java
@@ -22,6 +22,7 @@ public enum FamilyExceptionCode implements ExceptionCodeType {
     CANNOT_CHANGE_OWNER_ROLE("F012", "Family 소유자의 역할은 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     CANNOT_CHANGE_OWNER_STATUS("F013", "Family 소유자의 상태는 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     SELF_MODIFICATION_NOT_ALLOWED("F014", "자신의 역할이나 상태는 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVITED_MEMBER_BIRTHDAY_MODIFICATION_NOT_ALLOWED("F021", "초대된 멤버의 생일은 본인만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
     ADMIN_MODIFICATION_NOT_ALLOWED("F015", "관리자는 다른 관리자의 상태를 변경할 수 없습니다.", HttpStatus.FORBIDDEN),
     ANNOUNCEMENT_NOT_FOUND("F016", "존재하지 않는 공지사항입니다.", HttpStatus.NOT_FOUND),
     INVALID_ANNOUNCEMENT_REQUEST("F017", "잘못된 공지사항 요청입니다.", HttpStatus.BAD_REQUEST),

--- a/be/src/main/resources/data.sql
+++ b/be/src/main/resources/data.sql
@@ -1,0 +1,25 @@
+-- =====================================================
+-- 로컬 개발용 더미 데이터
+-- 초대 받은 멤버(userId 있음) vs 수동 등록 멤버(userId null) 테스트용
+-- =====================================================
+
+-- 테스트용 사용자 (초대 받은 멤버용)
+INSERT INTO users (id, email, name, profile_url, oauth2_provider, role, deleted, kakao_id, birthday, birthday_type, created_by, created_at, modified_by, modified_at)
+SELECT 900, 'invited@test.com', '초대멤버', 'https://example.com/invited.jpg', 'KAKAO', 'USER', false, 'kakao_invited_900', '1990-05-20 00:00:00', 'LUNAR', 900, NOW(), 900, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE id = 900);
+
+-- 가족 멤버 데이터 (family_id = 1 에 추가)
+-- 1. 초대 받은 멤버 (user_id 있음) - 생일 수정 불가 테스트용
+INSERT INTO family_member (id, family_id, user_id, name, profile_url, birthday, birthday_type, relationship_type, custom_relationship, status, role, created_by, created_at, modified_by, modified_at)
+SELECT 900, 1, 900, '초대된 가족', 'https://example.com/invited.jpg', '1990-05-20 00:00:00', 'LUNAR', 'YOUNGER_BROTHER', NULL, 'ACTIVE', 'MEMBER', 1, NOW(), 1, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM family_member WHERE id = 900);
+
+-- 2. 수동 등록 멤버 (user_id NULL) - 생일 수정 가능 테스트용 (반려동물)
+INSERT INTO family_member (id, family_id, user_id, name, profile_url, birthday, birthday_type, relationship_type, custom_relationship, status, role, created_by, created_at, modified_by, modified_at)
+SELECT 901, 1, NULL, '우리집 강아지', NULL, '2020-03-10 00:00:00', 'SOLAR', 'CUSTOM', '반려동물', 'ACTIVE', 'MEMBER', 1, NOW(), 1, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM family_member WHERE id = 901);
+
+-- 3. 수동 등록 멤버 (user_id NULL) - 생일 수정 가능 테스트용 (아이)
+INSERT INTO family_member (id, family_id, user_id, name, profile_url, birthday, birthday_type, relationship_type, custom_relationship, status, role, created_by, created_at, modified_by, modified_at)
+SELECT 902, 1, NULL, '막내아이', NULL, '2018-12-25 00:00:00', 'LUNAR', 'SON', NULL, 'ACTIVE', 'MEMBER', 1, NOW(), 1, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM family_member WHERE id = 902);

--- a/be/src/test/java/io/jhchoe/familytree/test/fixture/FamilyMemberFixture.java
+++ b/be/src/test/java/io/jhchoe/familytree/test/fixture/FamilyMemberFixture.java
@@ -177,4 +177,17 @@ public final class FamilyMemberFixture {
             status, role,
             1L, LocalDateTime.now(), 1L, LocalDateTime.now());
     }
+
+    // ==================== 수동 등록 멤버 (userId null) ====================
+
+    /**
+     * userId가 null인 수동 등록 멤버를 생성합니다.
+     * OWNER가 직접 등록한 멤버로, 초대장을 통해 가입하지 않은 멤버를 나타냅니다.
+     */
+    public static FamilyMember withIdAndNullUserId(Long id, Long familyId, FamilyMemberRole role) {
+        return FamilyMember.withId(id, familyId, null, DEFAULT_NAME, null, null, DEFAULT_PROFILE_URL,
+            DEFAULT_BIRTHDAY, DEFAULT_BIRTHDAY_TYPE,
+            FamilyMemberStatus.ACTIVE, role,
+            1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+    }
 }

--- a/fe/src/components/family/MemberDetailSheet.tsx
+++ b/fe/src/components/family/MemberDetailSheet.tsx
@@ -252,6 +252,7 @@ export const MemberDetailSheet: React.FC<MemberDetailSheetProps> = ({
           currentName={member.memberName}
           currentBirthday={member.memberBirthday}
           currentBirthdayType={member.memberBirthdayType}
+          isInvitedMember={member.member?.userId != null}
         />
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## 변경 목적
- 초대된 멤버(userId 있음)의 생일/생일타입은 본인만 수정 가능하도록 권한 제한
- 수동 등록 멤버(userId null)는 기존대로 OWNER/ADMIN이 모두 수정 가능

## 변경 내용

### 주요 변경사항

**Backend**
- `ModifyFamilyMemberInfoService`: 초대 멤버 생일 수정 제한 로직 추가
- `FamilyExceptionCode`: `INVITED_MEMBER_BIRTHDAY_MODIFICATION_NOT_ALLOWED` 예외 코드 추가
- 테스트 케이스 4개 추가 및 기존 테스트 시나리오 수정
- `data.sql`: 로컬 테스트용 더미데이터 추가

**Frontend**
- `MemberEditModal`: `isInvitedMember` prop 추가, 초대 멤버 생일 필드 비활성화
- `MemberDetailSheet`: `member.userId` 확인하여 `isInvitedMember` 전달

### 구현된 컴포넌트

| 멤버 유형 | userId | 이름 수정 | 생일/생일타입 수정 |
|----------|--------|----------|------------------|
| 수동 등록 | null | OWNER 가능 | OWNER 가능 |
| 초대장 가입 | 있음 | OWNER 가능 | **본인만** (프로필 설정) |

## 관련 문서
- 이슈: #52